### PR TITLE
Add Hashable instance for InternedString

### DIFF
--- a/Data/Interned/Internal/String.hs
+++ b/Data/Interned/Internal/String.hs
@@ -25,6 +25,9 @@ instance Ord InternedString where
 instance Show InternedString where
   showsPrec d (IS _ b) = showsPrec d b
 
+instance Hashable InternedString where
+  hashWithSalt s (IS i _) = hashWithSalt s i
+
 instance Interned InternedString where
   type Uninterned InternedString = String
   data Description InternedString = Cons {-# UNPACK #-} !Char String | Nil


### PR DESCRIPTION
This makes it possible to use `InternedString` in `HashMap`s with (hopefully) faster lookup/insert than a `Data.Map.Map`.