### PR TITLE
Make Data.Interned.IntSet.identity public

### DIFF
--- a/Data/Interned/IntSet.hs
+++ b/Data/Interned/IntSet.hs
@@ -49,6 +49,8 @@ module Data.Interned.IntSet  (
             -- * Set type
               IntSet          -- instance Eq,Show
 
+            , identity
+
             -- * Operators
             , (\\)
 
@@ -186,6 +188,7 @@ bin p m l r = intern (UBin p m l r)
 bin_ :: Prefix -> Mask -> IntSet -> IntSet -> IntSet
 bin_ p m l r = intern (UBin p m l r)
 
+-- | A unique integer ID associated with each interned set
 identity :: IntSet -> Id
 identity Nil = 0
 identity (Tip i _) = i


### PR DESCRIPTION
It would be convenient for me to be able to use the interned identity in my code as a unique ID -- it would save assigning new IDs and putting them in a `HashMap IntSet Int`.

Are these IDs guaranteed to be the same across program runs, or could they change due to e.g. hash conflicts?  If they can change, it would be worth putting that in the docs.