### PR TITLE
Minor speedups

### DIFF
--- a/Data/Interned/Internal.hs
+++ b/Data/Interned/Internal.hs
@@ -20,8 +20,12 @@ module Data.Interned.Internal
 
 import Data.Array
 import Data.Array.Base (unsafeWrite)
-import Data.Array.IO
+import Data.Array.IO (IOArray, newArray_)
+#if MIN_VERSION_base(4,5,0)
 import Data.Array.Unsafe (unsafeFreeze)
+#else
+import Data.Array.IO (unsafeFreeze)
+#endif
 import Data.Hashable
 import Data.HashMap.Strict (HashMap)
 import Data.Foldable
@@ -29,7 +33,13 @@ import Data.Foldable
 import Data.Traversable
 #endif
 import qualified Data.HashMap.Strict as HashMap
+#if MIN_VERSION_base(4,6,0) && !MIN_VERSION_base(4,8,0)
+-- These versions had a particularly inefficient implementation of
+-- atomicModifyIORef', so we use our own instead.
+import Data.IORef hiding (atomicModifyIORef')
+#else
 import Data.IORef
+#endif
 import GHC.IO (unsafeDupablePerformIO, unsafePerformIO)
 
 -- tuning parameter
@@ -113,3 +123,15 @@ recover :: Interned t => Description t -> IO (Maybe t)
 recover !dt = do
   CacheState _ m <- readIORef $ getCache cache ! (hash dt `mod` cacheWidth dt)
   return $ HashMap.lookup dt m
+
+#if !MIN_VERSION_base(4,8,0)
+-- For base<4.6, we define this because it's otherwise unavailable.
+-- For 4.6 <= base < 4.8, we define this because the version in base
+-- is gratuitously inefficient.
+atomicModifyIORef' :: IORef a -> (a -> (a,b)) -> IO b
+atomicModifyIORef' ref f = do
+    b <- atomicModifyIORef ref $ \a ->
+            case f a of
+                v@(a',_) -> a' `seq` v
+    b `seq` return b
+#endif


### PR DESCRIPTION
* Use `atomicModifyIORef'` instead of `atomicModifyIORef` to reduce the risk of accumulating a thunk chain in the `IORef`.
* Avoid `traverse`ing an `Array` in `mkCache`. This should speed up `IntSet` cache initialization.